### PR TITLE
Remove argument from list

### DIFF
--- a/my_class.dart
+++ b/my_class.dart
@@ -1,9 +1,8 @@
 class MyClass {
   final int? a1;
-  final int? a2;
   final int? a3;
   final int? a4;
   final int? a5;
 
-  const MyClass({this.a1, this.a2, this.a3, this.a4, this.a5});
+  const MyClass({this.a1, this.a3, this.a4, this.a5});
 }


### PR DESCRIPTION
Here we get a diff that is a lot harder to read than the clean diff we get with preserving commas, especially if the variable is only used in the constructor.
Compare to #3
