### PR TITLE
Preserve trailing commas

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+formatter:
+  trailing_commas: preserve

--- a/my_class.dart
+++ b/my_class.dart
@@ -1,16 +1,13 @@
 class MyClass {
   final int? a1;
-  final int? a2;
   final int? a3;
   final int? a4;
   final int? a5;
 
   const MyClass({
     this.a1,
-    this.a2,
     this.a3,
     this.a4,
     this.a5,
   });
 }
-


### PR DESCRIPTION
In this PR we can see how much cleaner the git diff is when preserving the trailing commas.